### PR TITLE
Build trade journaling web app with Go UI and MongoDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# best_trade_logs
+# Best Trade Logs
+
+Best Trade Logs is a Go web application that helps discretionary traders capture, review, and improve their trades. It provides a structured workflow for documenting trade plans, execution, post-trade analysis, and follow-up observations such as what happened 7 or 30 days after an exit.
+
+## Features
+
+- **Comprehensive trade capture** – record instrument, direction, entry and exit details, stop loss, target, fees, risk plan, and qualitative notes.
+- **Post-trade review** – log outcome summaries, psychology observations, improvement ideas, and tag trades for later filtering.
+- **Automatic metrics** – profit/loss, return percentages, R multiples, total risk, and target R are computed automatically.
+- **Follow-up tracking** – capture price observations days after the exit (e.g., +7 and +30) to evaluate missed follow-through moves.
+- **Unrealized tracking** – for open positions you can supply a reference close price to estimate current performance.
+- **Browser-based UI** – responsive HTML UI for listing trades, editing records, and drilling into trade details.
+
+## Running the application
+
+### Quick start (in-memory storage)
+
+The default build uses an in-memory repository, which is ideal for local experiments or when you want to try the UI quickly.
+
+```bash
+go run ./cmd/server
+```
+
+Open http://localhost:8080 to access the journal.
+
+### Using MongoDB
+
+Full persistence is enabled when compiling with the `mongodb` build tag. You need a running MongoDB instance and the official Go driver installed (run `go get go.mongodb.org/mongo-driver/mongo` in an environment with internet access).
+
+1. Export the required environment variables:
+
+```bash
+export MONGO_URI="mongodb://localhost:27017"
+export MONGO_DB="best_trade_logs"
+# optional override (defaults to "trades")
+export MONGO_COLLECTION="trades"
+```
+
+2. Build and run with MongoDB support:
+
+```bash
+go build -tags mongodb ./cmd/server
+go run -tags mongodb ./cmd/server
+```
+
+When MongoDB is enabled the server will connect on startup and persist trades inside the configured collection.
+
+### Configuration
+
+- `PORT` – HTTP port (defaults to `8080`).
+- `MONGO_URI`, `MONGO_DB`, `MONGO_COLLECTION` – required when running with the `mongodb` build tag.
+
+## Testing
+
+Run the unit test suite:
+
+```bash
+go test ./...
+```
+
+The tests cover domain calculations, repository behaviour, service workflows, and key HTTP handler logic.
+
+## Project structure
+
+- `cmd/server` – application entry point and repository setup logic.
+- `internal/domain/trade` – core trade entity and metric calculations.
+- `internal/service/trade` – orchestration logic for trade workflows.
+- `internal/storage` – in-memory and MongoDB repository implementations.
+- `internal/web` – HTTP handlers and view models.
+- `internal/web/templates` – HTML templates embedded into the binary.
+
+## Next steps
+
+- Add authentication and user accounts if you need multi-user support.
+- Extend filtering/search for tags, setups, or outcomes.
+- Integrate market data APIs to automatically populate follow-up prices or daily closes.
+- Export analytics to spreadsheets or dashboards.

--- a/README.md
+++ b/README.md
@@ -1,77 +1,77 @@
-# Best Trade Logs
+# 最佳交易日誌（Best Trade Logs）
 
-Best Trade Logs is a Go web application that helps discretionary traders capture, review, and improve their trades. It provides a structured workflow for documenting trade plans, execution, post-trade analysis, and follow-up observations such as what happened 7 or 30 days after an exit.
+最佳交易日誌是一個以 Go 實作的網頁應用程式，協助主觀交易員完整記錄、檢視並持續改善每一筆交易。系統提供一套結構化流程，用來整理交易計畫、實際執行、事後回顧，以及像是出場後第 7 天與第 30 天的市場表現等延伸觀察。
 
-## Features
+## 功能特色
 
-- **Comprehensive trade capture** – record instrument, direction, entry and exit details, stop loss, target, fees, risk plan, and qualitative notes.
-- **Post-trade review** – log outcome summaries, psychology observations, improvement ideas, and tag trades for later filtering.
-- **Automatic metrics** – profit/loss, return percentages, R multiples, total risk, and target R are computed automatically.
-- **Follow-up tracking** – capture price observations days after the exit (e.g., +7 and +30) to evaluate missed follow-through moves.
-- **Unrealized tracking** – for open positions you can supply a reference close price to estimate current performance.
-- **Browser-based UI** – responsive HTML UI for listing trades, editing records, and drilling into trade details.
+- **完整的交易紀錄表單**：紀錄商品、方向、進出場資訊、停損、目標、手續費、風險規劃與質化備註。
+- **交易回顧**：整理結果摘要、心理狀態、改進想法，並可替交易加上標籤以利後續篩選。
+- **自動化指標計算**：自動計算損益、報酬率、R 倍數、總風險與目標 R 值。
+- **後續追蹤**：記錄出場後數日（如 +7、+30）的價格觀察，評估錯過的延續走勢。
+- **未實現績效追蹤**：對於尚未出場的部位，可填寫參考收盤價來估算當前績效。
+- **瀏覽器介面**：提供響應式 HTML 介面，用於瀏覽清單、編輯紀錄與查看交易細節。
 
-## Running the application
+## 執行方式
 
-### Quick start (in-memory storage)
+### 快速體驗（記憶體儲存）
 
-The default build uses an in-memory repository, which is ideal for local experiments or when you want to try the UI quickly.
+預設建置會使用記憶體資料庫，適合在本地快速試用或體驗介面。
 
 ```bash
 go run ./cmd/server
 ```
 
-Open http://localhost:8080 to access the journal.
+開啟瀏覽器並造訪 http://localhost:8080 進入交易日誌。
 
-### Using MongoDB
+### 使用 MongoDB
 
-Full persistence is enabled when compiling with the `mongodb` build tag. You need a running MongoDB instance and the official Go driver installed (run `go get go.mongodb.org/mongo-driver/mongo` in an environment with internet access).
+若需要完整持久化，可在編譯時加入 `mongodb` build tag。請先準備可用的 MongoDB 服務，並安裝官方 Go Driver（在可連線的環境執行 `go get go.mongodb.org/mongo-driver/mongo`）。
 
-1. Export the required environment variables:
+1. 匯出必要環境變數：
 
 ```bash
 export MONGO_URI="mongodb://localhost:27017"
 export MONGO_DB="best_trade_logs"
-# optional override (defaults to "trades")
+# 可選，預設為 "trades"
 export MONGO_COLLECTION="trades"
 ```
 
-2. Build and run with MongoDB support:
+2. 以啟用 MongoDB 的方式建置與執行：
 
 ```bash
 go build -tags mongodb ./cmd/server
 go run -tags mongodb ./cmd/server
 ```
 
-When MongoDB is enabled the server will connect on startup and persist trades inside the configured collection.
+啟用 MongoDB 後，伺服器會在啟動時自動連線，並將交易資料存入指定的集合中。
 
-### Configuration
+### 設定參數
 
-- `PORT` – HTTP port (defaults to `8080`).
-- `MONGO_URI`, `MONGO_DB`, `MONGO_COLLECTION` – required when running with the `mongodb` build tag.
+- `PORT`：HTTP 埠號（預設為 `8080`）。
+- `MONGO_URI`、`MONGO_DB`、`MONGO_COLLECTION`：在使用 `mongodb` build tag 時必填。
 
-## Testing
+## 測試
 
-Run the unit test suite:
+執行單元測試：
 
 ```bash
 go test ./...
 ```
 
-The tests cover domain calculations, repository behaviour, service workflows, and key HTTP handler logic.
+測試涵蓋領域計算、儲存庫行為、服務流程與關鍵 HTTP Handler 邏輯。
 
-## Project structure
+## 專案結構
 
-- `cmd/server` – application entry point and repository setup logic.
-- `internal/domain/trade` – core trade entity and metric calculations.
-- `internal/service/trade` – orchestration logic for trade workflows.
-- `internal/storage` – in-memory and MongoDB repository implementations.
-- `internal/web` – HTTP handlers and view models.
-- `internal/web/templates` – HTML templates embedded into the binary.
+- `cmd/server`：應用程式進入點與儲存庫初始化邏輯。
+- `internal/domain/trade`：核心交易實體與指標計算。
+- `internal/service/trade`：交易流程的協調邏輯。
+- `internal/storage`：記憶體與 MongoDB 的儲存實作。
+- `internal/web`：HTTP Handler 與檢視模型。
+- `internal/web/templates`：嵌入程式的 HTML 樣板。
 
-## Next steps
+## 後續可延伸的方向
 
-- Add authentication and user accounts if you need multi-user support.
-- Extend filtering/search for tags, setups, or outcomes.
-- Integrate market data APIs to automatically populate follow-up prices or daily closes.
-- Export analytics to spreadsheets or dashboards.
+- 若需要多人使用，可加入認證與帳號管理。
+- 擴充標籤、策略或結果的篩選與搜尋功能。
+- 整合行情 API，自動填入出場後追蹤價或每日收盤價。
+- 匯出分析結果為試算表或儀表板。

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	tradesvc "best_trade_logs/internal/service/trade"
+	"best_trade_logs/internal/web"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	repo, cleanup, err := setupRepository(ctx)
+	if err != nil {
+		log.Fatalf("failed to setup repository: %v", err)
+	}
+	defer cleanup()
+
+	svc := tradesvc.NewService(repo)
+	server, err := web.NewServer(svc)
+	if err != nil {
+		log.Fatalf("failed to create server: %v", err)
+	}
+
+	addr := ":" + getEnv("PORT", "8080")
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      server.Handler(),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		log.Printf("Best Trade Logs listening on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("shutting down...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("server shutdown error: %v", err)
+	}
+}
+
+func getEnv(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return fallback
+}

--- a/cmd/server/setup_memory.go
+++ b/cmd/server/setup_memory.go
@@ -1,0 +1,15 @@
+//go:build !mongodb
+
+package main
+
+import (
+	"context"
+
+	"best_trade_logs/internal/storage"
+)
+
+func setupRepository(context.Context) (storage.TradeRepository, func(), error) {
+	repo := storage.NewInMemoryTradeRepository()
+	cleanup := func() {}
+	return repo, cleanup, nil
+}

--- a/cmd/server/setup_mongo.go
+++ b/cmd/server/setup_mongo.go
@@ -1,0 +1,55 @@
+//go:build mongodb
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"best_trade_logs/internal/storage"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func setupRepository(ctx context.Context) (storage.TradeRepository, func(), error) {
+	uri := os.Getenv("MONGO_URI")
+	if uri == "" {
+		return nil, nil, fmt.Errorf("MONGO_URI not provided")
+	}
+	db := os.Getenv("MONGO_DB")
+	if db == "" {
+		return nil, nil, fmt.Errorf("MONGO_DB not provided")
+	}
+	collection := os.Getenv("MONGO_COLLECTION")
+	if collection == "" {
+		collection = "trades"
+	}
+
+	client, err := mongo.NewClient(options.Client().ApplyURI(uri))
+	if err != nil {
+		return nil, nil, err
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := client.Connect(connectCtx); err != nil {
+		return nil, nil, err
+	}
+	if err := client.Ping(connectCtx, nil); err != nil {
+		_ = client.Disconnect(connectCtx)
+		return nil, nil, err
+	}
+
+	repo, err := storage.NewMongoTradeRepository(client, db, collection)
+	if err != nil {
+		_ = client.Disconnect(connectCtx)
+		return nil, nil, err
+	}
+	cleanup := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = client.Disconnect(shutdownCtx)
+	}
+	return repo, cleanup, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module best_trade_logs
+
+go 1.24.3

--- a/internal/domain/trade/trade.go
+++ b/internal/domain/trade/trade.go
@@ -1,0 +1,210 @@
+package trade
+
+import (
+	"math"
+	"time"
+)
+
+// Direction represents the direction of a trade (long or short).
+type Direction string
+
+const (
+	DirectionLong  Direction = "LONG"
+	DirectionShort Direction = "SHORT"
+)
+
+// EntryDetail captures information about entering a trade.
+type EntryDetail struct {
+	Date         time.Time `bson:"date"`
+	Price        float64   `bson:"price"`
+	Quantity     float64   `bson:"quantity"`
+	Fees         float64   `bson:"fees"`
+	StopLoss     *float64  `bson:"stop_loss"`
+	Target       *float64  `bson:"target"`
+	RiskPerShare *float64  `bson:"risk_per_share"`
+	Notes        string    `bson:"notes"`
+}
+
+// ExitDetail captures information when closing a trade.
+type ExitDetail struct {
+	Date     time.Time `bson:"date"`
+	Price    float64   `bson:"price"`
+	Quantity float64   `bson:"quantity"`
+	Fees     float64   `bson:"fees"`
+	Reason   string    `bson:"reason"`
+	Notes    string    `bson:"notes"`
+}
+
+// RiskManagement stores the parameters that helped manage the trade.
+type RiskManagement struct {
+	Thesis          string  `bson:"thesis"`
+	Plan            string  `bson:"plan"`
+	Checklist       string  `bson:"checklist"`
+	MaxRiskAmount   float64 `bson:"max_risk_amount"`
+	PositionSizing  string  `bson:"position_sizing"`
+	ContingencyPlan string  `bson:"contingency_plan"`
+}
+
+// FollowUp holds post-trade tracking information.
+type FollowUp struct {
+	DaysAfter int       `bson:"days_after"`
+	Price     float64   `bson:"price"`
+	Notes     string    `bson:"notes"`
+	LoggedAt  time.Time `bson:"logged_at"`
+}
+
+// TradeReview gathers lessons learnt from the trade.
+type TradeReview struct {
+	OutcomeSummary string   `bson:"outcome_summary"`
+	Psychology     string   `bson:"psychology"`
+	Improvements   string   `bson:"improvements"`
+	Tags           []string `bson:"tags"`
+}
+
+// Trade is the aggregate root representing a single trade.
+type Trade struct {
+	ID               string         `bson:"_id,omitempty"`
+	Instrument       string         `bson:"instrument"`
+	Market           string         `bson:"market"`
+	Direction        Direction      `bson:"direction"`
+	Setup            string         `bson:"setup"`
+	Entry            EntryDetail    `bson:"entry"`
+	Exit             *ExitDetail    `bson:"exit"`
+	RiskManagement   RiskManagement `bson:"risk_management"`
+	FollowUps        []FollowUp     `bson:"follow_ups"`
+	Review           TradeReview    `bson:"review"`
+	CreatedAt        time.Time      `bson:"created_at"`
+	UpdatedAt        time.Time      `bson:"updated_at"`
+	AdditionalNotes  string         `bson:"additional_notes"`
+	MarketContext    string         `bson:"market_context"`
+	ExecutionScore   *float64       `bson:"execution_score"`
+	ConfidenceBefore *float64       `bson:"confidence_before"`
+	ConfidenceAfter  *float64       `bson:"confidence_after"`
+}
+
+// GrossExposure calculates the notional size of the trade at entry.
+func (t Trade) GrossExposure() float64 {
+	return math.Abs(t.Entry.Price * t.Entry.Quantity)
+}
+
+// RiskPerShare calculates the assumed risk per share based on stop loss.
+func (t Trade) RiskPerShare() float64 {
+	if t.Entry.RiskPerShare != nil {
+		return *t.Entry.RiskPerShare
+	}
+	if t.Entry.StopLoss == nil {
+		return 0
+	}
+	stop := *t.Entry.StopLoss
+	if t.Direction == DirectionLong {
+		return t.Entry.Price - stop
+	}
+	return stop - t.Entry.Price
+}
+
+// TotalRiskAmount calculates the nominal risk of the trade.
+func (t Trade) TotalRiskAmount() float64 {
+	return t.RiskPerShare() * t.Entry.Quantity
+}
+
+// HasExited indicates whether the trade has been closed.
+func (t Trade) HasExited() bool {
+	return t.Exit != nil
+}
+
+// GrossResult calculates the gross profit or loss (before fees).
+func (t Trade) GrossResult() float64 {
+	if t.Exit == nil {
+		return 0
+	}
+	pnl := (t.Exit.Price - t.Entry.Price) * t.Entry.Quantity
+	if t.Direction == DirectionShort {
+		pnl = (t.Entry.Price - t.Exit.Price) * t.Entry.Quantity
+	}
+	return pnl
+}
+
+// NetResult accounts for both entry and exit fees.
+func (t Trade) NetResult() float64 {
+	if t.Exit == nil {
+		return -t.Entry.Fees
+	}
+	return t.GrossResult() - t.Entry.Fees - t.Exit.Fees
+}
+
+// ResultPercent expresses the net result as a percentage of gross exposure.
+func (t Trade) ResultPercent() float64 {
+	exposure := t.GrossExposure()
+	if exposure == 0 {
+		return 0
+	}
+	return (t.NetResult() / exposure) * 100
+}
+
+// RMultiple calculates the result in terms of risk multiples.
+func (t Trade) RMultiple() float64 {
+	risk := t.TotalRiskAmount()
+	if risk == 0 {
+		return 0
+	}
+	return t.NetResult() / risk
+}
+
+// FollowUpChangePercent returns the percentage change between the exit price
+// and a follow-up observation at the specified number of days.
+func (t Trade) FollowUpChangePercent(daysAfter int) (float64, bool) {
+	if t.Exit == nil {
+		return 0, false
+	}
+	for _, f := range t.FollowUps {
+		if f.DaysAfter == daysAfter {
+			if t.Exit.Price == 0 {
+				return 0, true
+			}
+			change := ((f.Price - t.Exit.Price) / t.Exit.Price) * 100
+			if t.Direction == DirectionShort {
+				change = ((t.Exit.Price - f.Price) / t.Exit.Price) * 100
+			}
+			return change, true
+		}
+	}
+	return 0, false
+}
+
+// UnrealizedResult calculates P/L using the latest close price provided.
+func (t Trade) UnrealizedResult(closePrice float64) float64 {
+	if t.HasExited() {
+		return t.NetResult()
+	}
+	pnl := (closePrice - t.Entry.Price) * t.Entry.Quantity
+	if t.Direction == DirectionShort {
+		pnl = (t.Entry.Price - closePrice) * t.Entry.Quantity
+	}
+	return pnl - t.Entry.Fees
+}
+
+// UnrealizedPercent calculates the unrealized return percentage.
+func (t Trade) UnrealizedPercent(closePrice float64) float64 {
+	exposure := t.GrossExposure()
+	if exposure == 0 {
+		return 0
+	}
+	return (t.UnrealizedResult(closePrice) / exposure) * 100
+}
+
+// EffectiveRewardTarget calculates the R multiple of the target price when provided.
+func (t Trade) EffectiveRewardTarget() float64 {
+	if t.Entry.Target == nil {
+		return 0
+	}
+	target := *t.Entry.Target
+	pnl := (target - t.Entry.Price) * t.Entry.Quantity
+	if t.Direction == DirectionShort {
+		pnl = (t.Entry.Price - target) * t.Entry.Quantity
+	}
+	risk := t.TotalRiskAmount()
+	if risk == 0 {
+		return 0
+	}
+	return pnl / risk
+}

--- a/internal/domain/trade/trade_test.go
+++ b/internal/domain/trade/trade_test.go
@@ -1,0 +1,85 @@
+package trade
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestNetResultLong(t *testing.T) {
+	exit := &ExitDetail{Date: time.Now(), Price: 120, Quantity: 10, Fees: 2}
+	tr := Trade{
+		Direction: DirectionLong,
+		Entry:     EntryDetail{Price: 100, Quantity: 10, Fees: 1},
+		Exit:      exit,
+	}
+	got := tr.NetResult()
+	want := ((120.0 - 100.0) * 10.0) - 1.0 - 2.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unexpected net result: got %v want %v", got, want)
+	}
+}
+
+func TestNetResultShort(t *testing.T) {
+	exit := &ExitDetail{Date: time.Now(), Price: 80, Quantity: 5, Fees: 3}
+	tr := Trade{
+		Direction: DirectionShort,
+		Entry:     EntryDetail{Price: 100, Quantity: 5, Fees: 1.5},
+		Exit:      exit,
+	}
+	got := tr.NetResult()
+	want := ((100.0 - 80.0) * 5.0) - 1.5 - 3.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unexpected net result: got %v want %v", got, want)
+	}
+}
+
+func TestRMultiple(t *testing.T) {
+	stop := 95.0
+	tr := Trade{
+		Direction: DirectionLong,
+		Entry:     EntryDetail{Price: 100, Quantity: 10, Fees: 0.5, StopLoss: &stop},
+	}
+	exit := &ExitDetail{Price: 115, Quantity: 10, Fees: 0.5}
+	tr.Exit = exit
+	if got := tr.RiskPerShare(); got != 5 {
+		t.Fatalf("expected risk per share 5, got %v", got)
+	}
+	wantRisk := 50.0
+	if got := tr.TotalRiskAmount(); got != wantRisk {
+		t.Fatalf("expected total risk %v, got %v", wantRisk, got)
+	}
+	wantR := (((115.0 - 100.0) * 10.0) - 1.0) / wantRisk
+	if math.Abs(tr.RMultiple()-wantR) > 1e-9 {
+		t.Fatalf("unexpected r multiple: got %v want %v", tr.RMultiple(), wantR)
+	}
+}
+
+func TestFollowUpChangePercent(t *testing.T) {
+	exit := &ExitDetail{Price: 100, Quantity: 10}
+	tr := Trade{
+		Direction: DirectionLong,
+		Entry:     EntryDetail{Price: 80, Quantity: 10},
+		Exit:      exit,
+		FollowUps: []FollowUp{{DaysAfter: 7, Price: 120}},
+	}
+	pct, ok := tr.FollowUpChangePercent(7)
+	if !ok {
+		t.Fatalf("expected follow up data")
+	}
+	if math.Abs(pct-20.0) > 1e-9 {
+		t.Fatalf("unexpected follow up pct: got %v", pct)
+	}
+}
+
+func TestUnrealizedResultForOpenTrade(t *testing.T) {
+	tr := Trade{
+		Direction: DirectionShort,
+		Entry:     EntryDetail{Price: 50, Quantity: 100, Fees: 5},
+	}
+	got := tr.UnrealizedResult(40)
+	want := ((50.0 - 40.0) * 100.0) - 5.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unexpected unrealized result: got %v want %v", got, want)
+	}
+}

--- a/internal/service/trade/service.go
+++ b/internal/service/trade/service.go
@@ -1,0 +1,84 @@
+package trade
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	domain "best_trade_logs/internal/domain/trade"
+	"best_trade_logs/internal/storage"
+)
+
+// Service coordinates higher-level trade workflows.
+type Service struct {
+	repo storage.TradeRepository
+}
+
+// NewService creates a trade service with the provided repository.
+func NewService(repo storage.TradeRepository) *Service {
+	return &Service{repo: repo}
+}
+
+// Create persists a new trade.
+func (s *Service) Create(ctx context.Context, tr *domain.Trade) error {
+	tr.CreatedAt = time.Now().UTC()
+	tr.UpdatedAt = tr.CreatedAt
+	normalize(tr)
+	return s.repo.Create(ctx, tr)
+}
+
+// Update modifies an existing trade.
+func (s *Service) Update(ctx context.Context, tr *domain.Trade) error {
+	tr.UpdatedAt = time.Now().UTC()
+	normalize(tr)
+	return s.repo.Update(ctx, tr)
+}
+
+// Delete removes a trade by ID.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return s.repo.Delete(ctx, id)
+}
+
+// Get fetches a trade by ID.
+func (s *Service) Get(ctx context.Context, id string) (*domain.Trade, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+// List retrieves all trades sorted by creation date desc.
+func (s *Service) List(ctx context.Context) ([]*domain.Trade, error) {
+	trades, err := s.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(trades, func(i, j int) bool {
+		return trades[i].CreatedAt.After(trades[j].CreatedAt)
+	})
+	return trades, nil
+}
+
+// AddFollowUp records a follow-up observation for the trade.
+func (s *Service) AddFollowUp(ctx context.Context, tradeID string, followUp domain.FollowUp) error {
+	tr, err := s.repo.GetByID(ctx, tradeID)
+	if err != nil {
+		return err
+	}
+	followUp.LoggedAt = time.Now().UTC()
+	tr.FollowUps = append(tr.FollowUps, followUp)
+	tr.UpdatedAt = followUp.LoggedAt
+	normalize(tr)
+	return s.repo.Update(ctx, tr)
+}
+
+func normalize(tr *domain.Trade) {
+	if tr.Review.Tags != nil {
+		cleaned := make([]string, 0, len(tr.Review.Tags))
+		for _, tag := range tr.Review.Tags {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				cleaned = append(cleaned, strings.ToLower(tag))
+			}
+		}
+		tr.Review.Tags = cleaned
+	}
+}

--- a/internal/service/trade/service_test.go
+++ b/internal/service/trade/service_test.go
@@ -1,0 +1,97 @@
+package trade
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domain "best_trade_logs/internal/domain/trade"
+	"best_trade_logs/internal/storage"
+)
+
+func TestServiceCreateAndList(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := NewService(repo)
+
+	tr := &domain.Trade{Instrument: "EURUSD", Entry: domain.EntryDetail{Price: 1.1, Quantity: 1000}}
+	if err := svc.Create(context.Background(), tr); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if tr.CreatedAt.IsZero() || tr.UpdatedAt.IsZero() {
+		t.Fatalf("timestamps should be set")
+	}
+
+	trades, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(trades))
+	}
+}
+
+func TestServiceAddFollowUp(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := NewService(repo)
+
+	tr := &domain.Trade{Instrument: "AAPL", Entry: domain.EntryDetail{Price: 150, Quantity: 10}}
+	if err := svc.Create(context.Background(), tr); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	fu := domain.FollowUp{DaysAfter: 7, Price: 165}
+	if err := svc.AddFollowUp(context.Background(), tr.ID, fu); err != nil {
+		t.Fatalf("add follow up failed: %v", err)
+	}
+
+	stored, err := svc.Get(context.Background(), tr.ID)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(stored.FollowUps) != 1 {
+		t.Fatalf("expected 1 follow up")
+	}
+	if stored.FollowUps[0].LoggedAt.IsZero() {
+		t.Fatalf("expected loggedAt to be set")
+	}
+}
+
+func TestNormalizeTags(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := NewService(repo)
+
+	tr := &domain.Trade{Instrument: "BTCUSD", Entry: domain.EntryDetail{Price: 20000, Quantity: 1}, Review: domain.TradeReview{Tags: []string{" Breakout ", "Momentum", ""}}}
+	if err := svc.Create(context.Background(), tr); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if len(tr.Review.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tr.Review.Tags))
+	}
+	if tr.Review.Tags[0] != "breakout" {
+		t.Fatalf("expected tags to be lower-cased and trimmed")
+	}
+}
+
+func TestUpdateKeepsCreatedAt(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := NewService(repo)
+
+	tr := &domain.Trade{Instrument: "ETHUSD", Entry: domain.EntryDetail{Price: 1200, Quantity: 5}}
+	if err := svc.Create(context.Background(), tr); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	created := tr.CreatedAt
+
+	time.Sleep(10 * time.Millisecond)
+	tr.Instrument = "ETHUSDT"
+	if err := svc.Update(context.Background(), tr); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	if !tr.CreatedAt.Equal(created) {
+		t.Fatalf("createdAt should remain unchanged")
+	}
+	if !tr.UpdatedAt.After(created) {
+		t.Fatalf("updatedAt should be later than createdAt")
+	}
+}

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -1,0 +1,106 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"best_trade_logs/internal/domain/trade"
+)
+
+// ErrNotFound is returned when a trade is not found in the repository.
+var ErrNotFound = errors.New("trade not found")
+
+// InMemoryTradeRepository provides an in-memory implementation for testing purposes.
+type InMemoryTradeRepository struct {
+	mu     sync.RWMutex
+	trades map[string]*trade.Trade
+}
+
+// NewInMemoryTradeRepository constructs an empty repository.
+func NewInMemoryTradeRepository() *InMemoryTradeRepository {
+	return &InMemoryTradeRepository{trades: make(map[string]*trade.Trade)}
+}
+
+// Create stores a new trade. If the trade does not have an ID it is generated using the timestamp.
+func (r *InMemoryTradeRepository) Create(_ context.Context, tr *trade.Trade) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if tr.ID == "" {
+		tr.ID = generateID()
+	}
+	now := time.Now().UTC()
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = now
+	}
+	tr.UpdatedAt = now
+
+	cp := *tr
+	r.trades[tr.ID] = &cp
+	return nil
+}
+
+// Update updates an existing trade.
+func (r *InMemoryTradeRepository) Update(_ context.Context, tr *trade.Trade) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if tr.ID == "" {
+		return ErrNotFound
+	}
+	if _, ok := r.trades[tr.ID]; !ok {
+		return ErrNotFound
+	}
+	cp := *tr
+	cp.UpdatedAt = time.Now().UTC()
+	r.trades[tr.ID] = &cp
+	return nil
+}
+
+// Delete removes a trade from the repository.
+func (r *InMemoryTradeRepository) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.trades[id]; !ok {
+		return ErrNotFound
+	}
+	delete(r.trades, id)
+	return nil
+}
+
+// GetByID retrieves a trade by its identifier.
+func (r *InMemoryTradeRepository) GetByID(_ context.Context, id string) (*trade.Trade, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	tr, ok := r.trades[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := *tr
+	return &cp, nil
+}
+
+// List returns the trades sorted by creation date descending.
+func (r *InMemoryTradeRepository) List(_ context.Context) ([]*trade.Trade, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	results := make([]*trade.Trade, 0, len(r.trades))
+	for _, tr := range r.trades {
+		cp := *tr
+		results = append(results, &cp)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].CreatedAt.After(results[j].CreatedAt)
+	})
+	return results, nil
+}
+
+func generateID() string {
+	return time.Now().UTC().Format("20060102T150405.000000000")
+}

--- a/internal/storage/memory_test.go
+++ b/internal/storage/memory_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"best_trade_logs/internal/domain/trade"
+)
+
+func TestInMemoryRepositoryCRUD(t *testing.T) {
+	repo := NewInMemoryTradeRepository()
+	ctx := context.Background()
+
+	entry := trade.EntryDetail{Price: 10, Quantity: 100}
+	tr := &trade.Trade{Instrument: "TSLA", Entry: entry, CreatedAt: time.Now().Add(-time.Hour)}
+	if err := repo.Create(ctx, tr); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if tr.ID == "" {
+		t.Fatalf("expected ID to be set")
+	}
+
+	stored, err := repo.GetByID(ctx, tr.ID)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if stored.Instrument != "TSLA" {
+		t.Fatalf("unexpected instrument: %v", stored.Instrument)
+	}
+
+	stored.Instrument = "AAPL"
+	if err := repo.Update(ctx, stored); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(list))
+	}
+	if list[0].Instrument != "AAPL" {
+		t.Fatalf("expected updated trade in list")
+	}
+
+	if err := repo.Delete(ctx, tr.ID); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	if _, err := repo.GetByID(ctx, tr.ID); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}

--- a/internal/storage/mongo.go
+++ b/internal/storage/mongo.go
@@ -1,0 +1,104 @@
+//go:build mongodb
+
+package storage
+
+import (
+	"context"
+	"time"
+
+	"best_trade_logs/internal/domain/trade"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// MongoTradeRepository persists trades in MongoDB.
+type MongoTradeRepository struct {
+	collection *mongo.Collection
+}
+
+// NewMongoTradeRepository constructs a Mongo backed repository.
+func NewMongoTradeRepository(client *mongo.Client, database, collection string) (*MongoTradeRepository, error) {
+	coll := client.Database(database).Collection(collection)
+	return &MongoTradeRepository{collection: coll}, nil
+}
+
+// Create inserts a new trade document.
+func (r *MongoTradeRepository) Create(ctx context.Context, tr *trade.Trade) error {
+	if tr.ID == "" {
+		tr.ID = primitive.NewObjectID().Hex()
+	}
+	now := time.Now().UTC()
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = now
+	}
+	tr.UpdatedAt = now
+	_, err := r.collection.InsertOne(ctx, tr)
+	return err
+}
+
+// Update replaces an existing trade document.
+func (r *MongoTradeRepository) Update(ctx context.Context, tr *trade.Trade) error {
+	if tr.ID == "" {
+		return ErrNotFound
+	}
+	tr.UpdatedAt = time.Now().UTC()
+	filter := bson.M{"_id": tr.ID}
+	result, err := r.collection.ReplaceOne(ctx, filter, tr, options.Replace().SetUpsert(false))
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes a trade document.
+func (r *MongoTradeRepository) Delete(ctx context.Context, id string) error {
+	result, err := r.collection.DeleteOne(ctx, bson.M{"_id": id})
+	if err != nil {
+		return err
+	}
+	if result.DeletedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetByID fetches a trade document by id.
+func (r *MongoTradeRepository) GetByID(ctx context.Context, id string) (*trade.Trade, error) {
+	var tr trade.Trade
+	err := r.collection.FindOne(ctx, bson.M{"_id": id}).Decode(&tr)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &tr, nil
+}
+
+// List returns trades sorted by creation date (desc).
+func (r *MongoTradeRepository) List(ctx context.Context) ([]*trade.Trade, error) {
+	opts := options.Find().SetSort(bson.D{{Key: "created_at", Value: -1}})
+	cursor, err := r.collection.Find(ctx, bson.D{}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []*trade.Trade
+	for cursor.Next(ctx) {
+		var tr trade.Trade
+		if err := cursor.Decode(&tr); err != nil {
+			return nil, err
+		}
+		results = append(results, &tr)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/internal/storage/mongo_stub.go
+++ b/internal/storage/mongo_stub.go
@@ -1,0 +1,46 @@
+//go:build !mongodb
+
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"best_trade_logs/internal/domain/trade"
+)
+
+// ErrMongoUnavailable indicates that the binary was built without MongoDB support.
+var ErrMongoUnavailable = errors.New("mongoDB support not built; rebuild with -tags mongodb")
+
+// MongoTradeRepository is a stub implementation used when MongoDB support is disabled.
+type MongoTradeRepository struct{}
+
+// NewMongoTradeRepository returns an error indicating MongoDB support is unavailable.
+func NewMongoTradeRepository(_ interface{}, _ string, _ string) (*MongoTradeRepository, error) {
+	return nil, ErrMongoUnavailable
+}
+
+// Create returns an error because MongoDB is unavailable.
+func (r *MongoTradeRepository) Create(context.Context, *trade.Trade) error {
+	return ErrMongoUnavailable
+}
+
+// Update returns an error because MongoDB is unavailable.
+func (r *MongoTradeRepository) Update(context.Context, *trade.Trade) error {
+	return ErrMongoUnavailable
+}
+
+// Delete returns an error because MongoDB is unavailable.
+func (r *MongoTradeRepository) Delete(context.Context, string) error {
+	return ErrMongoUnavailable
+}
+
+// GetByID returns an error because MongoDB is unavailable.
+func (r *MongoTradeRepository) GetByID(context.Context, string) (*trade.Trade, error) {
+	return nil, ErrMongoUnavailable
+}
+
+// List returns an error because MongoDB is unavailable.
+func (r *MongoTradeRepository) List(context.Context) ([]*trade.Trade, error) {
+	return nil, ErrMongoUnavailable
+}

--- a/internal/storage/trade_repository.go
+++ b/internal/storage/trade_repository.go
@@ -1,0 +1,16 @@
+package storage
+
+import (
+	"context"
+
+	"best_trade_logs/internal/domain/trade"
+)
+
+// TradeRepository describes the persistence operations required by the service layer.
+type TradeRepository interface {
+	Create(ctx context.Context, tr *trade.Trade) error
+	Update(ctx context.Context, tr *trade.Trade) error
+	Delete(ctx context.Context, id string) error
+	GetByID(ctx context.Context, id string) (*trade.Trade, error)
+	List(ctx context.Context) ([]*trade.Trade, error)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,475 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "best_trade_logs/internal/domain/trade"
+	tradesvc "best_trade_logs/internal/service/trade"
+	"best_trade_logs/internal/storage"
+	"best_trade_logs/internal/web/templates"
+)
+
+// Server wires the HTTP layer with the trade service.
+type Server struct {
+	svc       *tradesvc.Service
+	templates *template.Template
+}
+
+// NewServer builds a Server with embedded templates parsed.
+func NewServer(svc *tradesvc.Service) (*Server, error) {
+	tmpl, err := templates.New()
+	if err != nil {
+		return nil, err
+	}
+	return &Server{svc: svc, templates: tmpl}, nil
+}
+
+// Handler exposes the configured HTTP handler.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/trades", s.handleTrades)
+	mux.HandleFunc("/trades/new", s.handleNewTrade)
+	mux.HandleFunc("/trades/", s.handleTradeRoutes)
+	return mux
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	ctx := r.Context()
+	trades, err := s.svc.List(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	summaries := make([]tradeSummary, 0, len(trades))
+	for _, tr := range trades {
+		summary := tradeSummary{Trade: tr, NetResult: tr.NetResult(), ResultPercent: tr.ResultPercent(), RMultiple: tr.RMultiple()}
+		if v, ok := tr.FollowUpChangePercent(7); ok {
+			val := v
+			summary.FollowUp7 = &val
+		}
+		if v, ok := tr.FollowUpChangePercent(30); ok {
+			val := v
+			summary.FollowUp30 = &val
+		}
+		summaries = append(summaries, summary)
+	}
+
+	data := struct {
+		Trades []tradeSummary
+		Flash  string
+	}{
+		Trades: summaries,
+		Flash:  r.URL.Query().Get("flash"),
+	}
+
+	s.render(w, "index.gohtml", data)
+}
+
+func (s *Server) handleTrades(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleCreateTrade(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleNewTrade(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.NotFound(w, r)
+		return
+	}
+	tr := &domain.Trade{}
+	tr.Direction = domain.DirectionLong
+	data := map[string]interface{}{
+		"Title":  "Record new trade",
+		"Trade":  tr,
+		"Action": "/trades",
+	}
+	s.render(w, "trade_form.gohtml", data)
+}
+
+func (s *Server) handleTradeRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/trades/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 || parts[0] == "" {
+		http.NotFound(w, r)
+		return
+	}
+	id := parts[0]
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		s.handleShowTrade(w, r, id)
+	case len(parts) == 2 && parts[1] == "edit" && r.Method == http.MethodGet:
+		s.handleEditTrade(w, r, id)
+	case len(parts) == 2 && parts[1] == "update" && r.Method == http.MethodPost:
+		s.handleUpdateTrade(w, r, id)
+	case len(parts) == 2 && parts[1] == "delete" && r.Method == http.MethodPost:
+		s.handleDeleteTrade(w, r, id)
+	case len(parts) == 2 && parts[1] == "followups" && r.Method == http.MethodPost:
+		s.handleAddFollowUp(w, r, id)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleCreateTrade(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	tr, errs := buildTradeFromForm(r)
+	if len(errs) > 0 {
+		http.Error(w, strings.Join(errs, "; "), http.StatusBadRequest)
+		return
+	}
+	if err := s.svc.Create(r.Context(), tr); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/trades/%s?flash=Trade%%20recorded", tr.ID), http.StatusSeeOther)
+}
+
+func (s *Server) handleShowTrade(w http.ResponseWriter, r *http.Request, id string) {
+	tr, err := s.svc.Get(r.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	metrics := buildTradeMetrics(tr, r.URL.Query().Get("close_price"))
+
+	data := map[string]interface{}{
+		"Trade":      tr,
+		"Metrics":    metrics,
+		"QueryClose": metrics.QueryClose,
+		"Flash":      r.URL.Query().Get("flash"),
+	}
+	s.render(w, "trade_detail.gohtml", data)
+}
+
+func (s *Server) handleEditTrade(w http.ResponseWriter, r *http.Request, id string) {
+	tr, err := s.svc.Get(r.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	data := map[string]interface{}{
+		"Title":  "Edit trade",
+		"Trade":  tr,
+		"Action": fmt.Sprintf("/trades/%s/update", tr.ID),
+	}
+	s.render(w, "trade_form.gohtml", data)
+}
+
+func (s *Server) handleUpdateTrade(w http.ResponseWriter, r *http.Request, id string) {
+	existing, err := s.svc.Get(r.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	tr, errs := buildTradeFromForm(r)
+	if len(errs) > 0 {
+		http.Error(w, strings.Join(errs, "; "), http.StatusBadRequest)
+		return
+	}
+	tr.ID = existing.ID
+	tr.CreatedAt = existing.CreatedAt
+	tr.FollowUps = existing.FollowUps
+	if err := s.svc.Update(r.Context(), tr); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/trades/%s?flash=Trade%%20updated", tr.ID), http.StatusSeeOther)
+}
+
+func (s *Server) handleDeleteTrade(w http.ResponseWriter, r *http.Request, id string) {
+	if err := s.svc.Delete(r.Context(), id); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	http.Redirect(w, r, "/?flash=Trade%%20deleted", http.StatusSeeOther)
+}
+
+func (s *Server) handleAddFollowUp(w http.ResponseWriter, r *http.Request, id string) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	days, err := strconv.Atoi(strings.TrimSpace(r.FormValue("days_after")))
+	if err != nil {
+		http.Error(w, "invalid days", http.StatusBadRequest)
+		return
+	}
+	price, err := strconv.ParseFloat(strings.TrimSpace(r.FormValue("price")), 64)
+	if err != nil {
+		http.Error(w, "invalid price", http.StatusBadRequest)
+		return
+	}
+	follow := domain.FollowUp{DaysAfter: days, Price: price, Notes: strings.TrimSpace(r.FormValue("notes"))}
+	if err := s.svc.AddFollowUp(r.Context(), id, follow); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/trades/%s?flash=Follow-up%%20added", id), http.StatusSeeOther)
+}
+
+func (s *Server) render(w http.ResponseWriter, name string, data interface{}) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.templates.ExecuteTemplate(w, name, data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+type tradeSummary struct {
+	*domain.Trade
+	NetResult     float64
+	ResultPercent float64
+	RMultiple     float64
+	FollowUp7     *float64
+	FollowUp30    *float64
+}
+
+type tradeMetrics struct {
+	Net           float64
+	NetPercent    float64
+	RMultiple     float64
+	TotalRisk     float64
+	TargetR       float64
+	FollowUp7     *float64
+	FollowUp30    *float64
+	Unrealized    float64
+	UnrealizedPct float64
+	QueryClose    *float64
+}
+
+func buildTradeMetrics(tr *domain.Trade, closePrice string) tradeMetrics {
+	metrics := tradeMetrics{
+		Net:        tr.NetResult(),
+		NetPercent: tr.ResultPercent(),
+		RMultiple:  tr.RMultiple(),
+		TotalRisk:  tr.TotalRiskAmount(),
+		TargetR:    tr.EffectiveRewardTarget(),
+	}
+	if v, ok := tr.FollowUpChangePercent(7); ok {
+		val := v
+		metrics.FollowUp7 = &val
+	}
+	if v, ok := tr.FollowUpChangePercent(30); ok {
+		val := v
+		metrics.FollowUp30 = &val
+	}
+	if strings.TrimSpace(closePrice) != "" {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(closePrice), 64); err == nil {
+			metrics.Unrealized = tr.UnrealizedResult(v)
+			metrics.UnrealizedPct = tr.UnrealizedPercent(v)
+			metrics.QueryClose = &v
+		}
+	}
+	return metrics
+}
+
+func buildTradeFromForm(r *http.Request) (*domain.Trade, []string) {
+	var errs []string
+	get := func(name string) string { return strings.TrimSpace(r.FormValue(name)) }
+
+	tr := &domain.Trade{}
+	tr.Instrument = get("instrument")
+	tr.Market = get("market")
+	tr.Setup = get("setup")
+	tr.Direction = domain.Direction(strings.ToUpper(get("direction")))
+	if tr.Direction != domain.DirectionLong && tr.Direction != domain.DirectionShort {
+		tr.Direction = domain.DirectionLong
+	}
+
+	entryDateStr := get("entry_date")
+	if entryDateStr == "" {
+		errs = append(errs, "entry date is required")
+	} else {
+		if dt, err := time.Parse("2006-01-02", entryDateStr); err == nil {
+			tr.Entry.Date = dt
+		} else {
+			errs = append(errs, "invalid entry date")
+		}
+	}
+
+	var err error
+	if tr.Entry.Price, err = parseRequiredFloat(get("entry_price")); err != nil {
+		errs = append(errs, "invalid entry price")
+	}
+	if tr.Entry.Quantity, err = parseRequiredFloat(get("entry_quantity")); err != nil {
+		errs = append(errs, "invalid quantity")
+	}
+	if tr.Entry.Fees, err = parseOptionalFloat(get("entry_fees"), 0); err != nil {
+		errs = append(errs, "invalid entry fees")
+	}
+	if tr.Entry.StopLoss, err = parseOptionalPtrFloat(get("entry_stop_loss")); err != nil {
+		errs = append(errs, "invalid stop loss")
+	}
+	if tr.Entry.Target, err = parseOptionalPtrFloat(get("entry_target")); err != nil {
+		errs = append(errs, "invalid target")
+	}
+	if tr.Entry.RiskPerShare, err = parseOptionalPtrFloat(get("entry_risk")); err != nil {
+		errs = append(errs, "invalid manual risk per share")
+	}
+	tr.Entry.Notes = get("entry_notes")
+
+	tr.RiskManagement = domain.RiskManagement{
+		Thesis:          get("thesis"),
+		Plan:            get("plan"),
+		Checklist:       get("checklist"),
+		PositionSizing:  get("position_sizing"),
+		ContingencyPlan: get("contingency_plan"),
+	}
+	if tr.RiskManagement.MaxRiskAmount, err = parseOptionalFloat(get("max_risk"), 0); err != nil {
+		errs = append(errs, "invalid max risk")
+	}
+
+	exitProvided := false
+	if dateStr := get("exit_date"); dateStr != "" {
+		if dt, err := time.Parse("2006-01-02", dateStr); err == nil {
+			ensureExit(tr)
+			tr.Exit.Date = dt
+			exitProvided = true
+		} else {
+			errs = append(errs, "invalid exit date")
+		}
+	}
+	if priceStr := get("exit_price"); priceStr != "" {
+		if val, err := strconv.ParseFloat(priceStr, 64); err == nil {
+			ensureExit(tr)
+			tr.Exit.Price = val
+			exitProvided = true
+		} else {
+			errs = append(errs, "invalid exit price")
+		}
+	}
+	if qtyStr := get("exit_quantity"); qtyStr != "" {
+		if val, err := strconv.ParseFloat(qtyStr, 64); err == nil {
+			ensureExit(tr)
+			tr.Exit.Quantity = val
+			exitProvided = true
+		} else {
+			errs = append(errs, "invalid exit quantity")
+		}
+	}
+	if feeStr := get("exit_fees"); feeStr != "" {
+		if val, err := strconv.ParseFloat(feeStr, 64); err == nil {
+			ensureExit(tr)
+			tr.Exit.Fees = val
+			exitProvided = true
+		} else {
+			errs = append(errs, "invalid exit fees")
+		}
+	}
+	if reason := get("exit_reason"); reason != "" {
+		ensureExit(tr)
+		tr.Exit.Reason = reason
+		exitProvided = true
+	}
+	if notes := get("exit_notes"); notes != "" {
+		ensureExit(tr)
+		tr.Exit.Notes = notes
+		exitProvided = true
+	}
+	if tr.Exit != nil && !exitProvided {
+		tr.Exit = nil
+	}
+	if tr.Exit != nil && tr.Exit.Quantity == 0 {
+		tr.Exit.Quantity = tr.Entry.Quantity
+	}
+
+	tr.Review = domain.TradeReview{
+		OutcomeSummary: get("outcome"),
+		Psychology:     get("psychology"),
+		Improvements:   get("improvements"),
+	}
+	if tags := get("tags"); tags != "" {
+		parts := strings.Split(tags, ",")
+		tr.Review.Tags = parts
+	}
+
+	tr.MarketContext = get("market_context")
+	tr.AdditionalNotes = get("additional_notes")
+
+	if tr.ExecutionScore, err = parseOptionalPtrFloat(get("execution_score")); err != nil {
+		errs = append(errs, "invalid execution score")
+	}
+	if tr.ConfidenceBefore, err = parseOptionalPtrFloat(get("confidence_before")); err != nil {
+		errs = append(errs, "invalid confidence before")
+	}
+	if tr.ConfidenceAfter, err = parseOptionalPtrFloat(get("confidence_after")); err != nil {
+		errs = append(errs, "invalid confidence after")
+	}
+
+	return tr, errs
+}
+
+func parseRequiredFloat(val string) (float64, error) {
+	return strconv.ParseFloat(val, 64)
+}
+
+func parseOptionalFloat(val string, def float64) (float64, error) {
+	if strings.TrimSpace(val) == "" {
+		return def, nil
+	}
+	return strconv.ParseFloat(val, 64)
+}
+
+func parseOptionalPtrFloat(val string) (*float64, error) {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return nil, nil
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func ensureExit(tr *domain.Trade) {
+	if tr.Exit == nil {
+		tr.Exit = &domain.ExitDetail{}
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	domain "best_trade_logs/internal/domain/trade"
+	tradesvc "best_trade_logs/internal/service/trade"
+	"best_trade_logs/internal/storage"
+)
+
+func TestBuildTradeFromFormParsesExit(t *testing.T) {
+	form := url.Values{}
+	form.Set("instrument", "AAPL")
+	form.Set("direction", "LONG")
+	form.Set("entry_date", "2023-01-02")
+	form.Set("entry_price", "100")
+	form.Set("entry_quantity", "10")
+	form.Set("entry_fees", "2")
+	form.Set("exit_date", "2023-01-05")
+	form.Set("exit_price", "110")
+	form.Set("exit_quantity", "10")
+	form.Set("exit_fees", "1")
+
+	req := httptest.NewRequest(http.MethodPost, "/trades", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("parse form: %v", err)
+	}
+
+	tr, errs := buildTradeFromForm(req)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if tr.Exit == nil {
+		t.Fatalf("expected exit to be parsed")
+	}
+	if tr.Exit.Price != 110 {
+		t.Fatalf("unexpected exit price: %v", tr.Exit.Price)
+	}
+}
+
+func TestHandleCreateTradePersists(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := tradesvc.NewService(repo)
+	server, err := NewServer(svc)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("instrument", "EURUSD")
+	form.Set("direction", "SHORT")
+	form.Set("entry_date", "2023-01-02")
+	form.Set("entry_price", "1.1")
+	form.Set("entry_quantity", "1000")
+
+	req := httptest.NewRequest(http.MethodPost, "/trades", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	server.handleCreateTrade(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", rec.Code)
+	}
+	trades, err := repo.List(req.Context())
+	if err != nil {
+		t.Fatalf("list trades: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(trades))
+	}
+}
+
+func TestHandleUpdateTradeKeepsFollowUps(t *testing.T) {
+	repo := storage.NewInMemoryTradeRepository()
+	svc := tradesvc.NewService(repo)
+	server, err := NewServer(svc)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	tr := &domain.Trade{Instrument: "BTCUSD", Entry: domain.EntryDetail{Date: time.Now(), Price: 20000, Quantity: 1}}
+	if err := svc.Create(testContext(), tr); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	follow := domain.FollowUp{DaysAfter: 7, Price: 22000}
+	if err := svc.AddFollowUp(testContext(), tr.ID, follow); err != nil {
+		t.Fatalf("add follow up: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("instrument", "BTCUSD")
+	form.Set("direction", "LONG")
+	form.Set("entry_date", tr.Entry.Date.Format("2006-01-02"))
+	form.Set("entry_price", "21000")
+	form.Set("entry_quantity", "1")
+
+	req := httptest.NewRequest(http.MethodPost, "/trades/"+tr.ID+"/update", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	server.handleUpdateTrade(rec, req, tr.ID)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", rec.Code)
+	}
+	updated, err := svc.Get(req.Context(), tr.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(updated.FollowUps) != 1 {
+		t.Fatalf("expected follow ups to persist")
+	}
+}
+
+func testContext() context.Context {
+	return httptest.NewRequest(http.MethodGet, "/", nil).Context()
+}

--- a/internal/web/templates/index.gohtml
+++ b/internal/web/templates/index.gohtml
@@ -1,0 +1,45 @@
+{{define "title"}}Trade Journal{{end}}
+{{define "content"}}
+<div class="flex" style="justify-content: space-between;">
+    <h1>Trade Journal</h1>
+    <a class="btn" href="/trades/new">Record new trade</a>
+</div>
+
+{{if .Flash}}
+<div class="alert">{{.Flash}}</div>
+{{end}}
+
+<table>
+    <thead>
+        <tr>
+            <th>Instrument</th>
+            <th>Direction</th>
+            <th>Entry</th>
+            <th>Exit</th>
+            <th>P&amp;L</th>
+            <th>R Multiple</th>
+            <th>7D After</th>
+            <th>30D After</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {{range .Trades}}
+        <tr>
+            <td>{{.Instrument}}</td>
+            <td>{{.Direction}}</td>
+            <td>{{.Entry.Date.Format "2006-01-02"}} @ {{printf "%.2f" .Entry.Price}}</td>
+            <td>{{if .Exit}}{{.Exit.Date.Format "2006-01-02"}} @ {{printf "%.2f" .Exit.Price}}{{else}}Open{{end}}</td>
+            <td>{{printf "%.2f" .NetResult}} ({{printf "%.2f" .ResultPercent}}%)</td>
+            <td>{{printf "%.2f" .RMultiple}}</td>
+            <td>{{if .FollowUp7}}{{printf "%.2f" .FollowUp7}}%{{else}}-{{end}}</td>
+            <td>{{if .FollowUp30}}{{printf "%.2f" .FollowUp30}}%{{else}}-{{end}}</td>
+            <td><a class="btn-secondary" href="/trades/{{.ID}}">View</a></td>
+        </tr>
+    {{else}}
+        <tr><td colspan="9">No trades logged yet.</td></tr>
+    {{end}}
+    </tbody>
+</table>
+{{end}}
+{{template "layout" .}}

--- a/internal/web/templates/layout.gohtml
+++ b/internal/web/templates/layout.gohtml
@@ -1,0 +1,50 @@
+{{define "layout"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{block "title" .}}Best Trade Logs{{end}}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+        header { background: #1f2937; color: #fff; padding: 1.2rem; }
+        header a { color: #fff; text-decoration: none; font-weight: bold; }
+        main { padding: 1.5rem; }
+        .container { max-width: 1200px; margin: 0 auto; background: #fff; padding: 1.5rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd; text-align: left; }
+        th { background: #f0f4f8; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; }
+        .actions { display: flex; gap: 0.5rem; }
+        form { margin-top: 1rem; }
+        label { display: block; font-weight: 600; margin-top: 0.75rem; }
+        input[type="text"], input[type="number"], input[type="date"], textarea { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
+        textarea { min-height: 80px; }
+        .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+        .btn { display: inline-block; padding: 0.5rem 1rem; border-radius: 4px; border: none; background: #2563eb; color: #fff; cursor: pointer; }
+        .btn-secondary { background: #6b7280; }
+        .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-top: 1rem; }
+        .metric-card { background: #f9fafb; padding: 1rem; border-radius: 8px; border: 1px solid #e5e7eb; }
+        .metric-card h4 { margin: 0 0 0.5rem 0; font-size: 0.95rem; color: #374151; }
+        .metric-card p { margin: 0; font-size: 1.1rem; font-weight: bold; color: #111827; }
+        .badge { padding: 0.25rem 0.5rem; background: #e0e7ff; color: #1e3a8a; border-radius: 9999px; font-size: 0.75rem; margin-right: 0.25rem; display: inline-block; }
+        .section { margin-top: 2rem; }
+        .section h3 { margin-bottom: 0.5rem; }
+        .alert { padding: 0.75rem 1rem; background: #fee2e2; color: #991b1b; border-radius: 4px; margin-top: 1rem; }
+        .flex { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
+        .tag { background: #d1fae5; color: #065f46; padding: 0.2rem 0.5rem; border-radius: 9999px; font-size: 0.8rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container" style="background:none; box-shadow:none;">
+            <a href="/">Best Trade Logs</a>
+        </div>
+    </header>
+    <main>
+        <div class="container">
+            {{template "content" .}}
+        </div>
+    </main>
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/templates.go
+++ b/internal/web/templates/templates.go
@@ -1,0 +1,38 @@
+package templates
+
+import (
+    "embed"
+    "html/template"
+    "strings"
+
+    domain "best_trade_logs/internal/domain/trade"
+)
+
+//go:embed *.gohtml
+var templateFS embed.FS
+
+// New parses the embedded templates with helper functions configured.
+func New() (*template.Template, error) {
+    funcMap := template.FuncMap{
+        "ptrValue": func(v *float64) float64 {
+            if v == nil {
+                return 0
+            }
+            return *v
+        },
+        "join": func(values []string, sep string) string {
+            return strings.Join(values, sep)
+        },
+        "followUpChange": func(tr *domain.Trade, fu domain.FollowUp) float64 {
+            if tr == nil {
+                return 0
+            }
+            if pct, ok := tr.FollowUpChangePercent(fu.DaysAfter); ok {
+                return pct
+            }
+            return 0
+        },
+    }
+
+    return template.New("base").Funcs(funcMap).ParseFS(templateFS, "*.gohtml")
+}

--- a/internal/web/templates/trade_detail.gohtml
+++ b/internal/web/templates/trade_detail.gohtml
@@ -1,0 +1,152 @@
+{{define "title"}}Trade - {{.Trade.Instrument}}{{end}}
+{{define "content"}}
+<div class="flex" style="justify-content: space-between; align-items:center;">
+    <h1>{{.Trade.Instrument}} ({{.Trade.Direction}})</h1>
+    <div class="actions">
+        <a class="btn" href="/trades/{{.Trade.ID}}/edit">Edit</a>
+        <form method="post" action="/trades/{{.Trade.ID}}/delete" onsubmit="return confirm('Delete this trade?');">
+            <button class="btn-secondary" type="submit">Delete</button>
+        </form>
+    </div>
+</div>
+{{if .Flash}}
+<div class="alert">{{.Flash}}</div>
+{{end}}
+<p><strong>Setup:</strong> {{.Trade.Setup}} | <strong>Market:</strong> {{.Trade.Market}}</p>
+<p><strong>Created:</strong> {{.Trade.CreatedAt.Format "2006-01-02 15:04"}}</p>
+
+<div class="metrics">
+    <div class="metric-card">
+        <h4>Net P&amp;L</h4>
+        <p>{{printf "%.2f" .Metrics.Net}} ({{printf "%.2f" .Metrics.NetPercent}}%)</p>
+    </div>
+    <div class="metric-card">
+        <h4>R Multiple</h4>
+        <p>{{printf "%.2f" .Metrics.RMultiple}}</p>
+    </div>
+    <div class="metric-card">
+        <h4>Total Risk</h4>
+        <p>{{printf "%.2f" .Metrics.TotalRisk}}</p>
+    </div>
+    <div class="metric-card">
+        <h4>Exit vs 7 days</h4>
+        <p>{{if .Metrics.FollowUp7}}{{printf "%.2f" .Metrics.FollowUp7}}%{{else}}N/A{{end}}</p>
+    </div>
+    <div class="metric-card">
+        <h4>Exit vs 30 days</h4>
+        <p>{{if .Metrics.FollowUp30}}{{printf "%.2f" .Metrics.FollowUp30}}%{{else}}N/A{{end}}</p>
+    </div>
+    <div class="metric-card">
+        <h4>Target R</h4>
+        <p>{{printf "%.2f" .Metrics.TargetR}}</p>
+    </div>
+</div>
+
+<div class="section">
+    <h3>Entry</h3>
+    <p>{{.Trade.Entry.Date.Format "2006-01-02"}} @ {{printf "%.2f" .Trade.Entry.Price}} | Qty: {{printf "%.2f" .Trade.Entry.Quantity}} | Fees: {{printf "%.2f" .Trade.Entry.Fees}}</p>
+    {{if .Trade.Entry.StopLoss}}<p>Stop loss: {{printf "%.2f" (ptrValue .Trade.Entry.StopLoss)}}</p>{{end}}
+    {{if .Trade.Entry.Target}}<p>Target: {{printf "%.2f" (ptrValue .Trade.Entry.Target)}} ({{printf "%.2f" .Metrics.TargetR}}R)</p>{{end}}
+    {{if .Trade.Entry.Notes}}<p>{{.Trade.Entry.Notes}}</p>{{end}}
+</div>
+
+<div class="section">
+    <h3>Exit</h3>
+    {{if .Trade.Exit}}
+        <p>{{.Trade.Exit.Date.Format "2006-01-02"}} @ {{printf "%.2f" .Trade.Exit.Price}} | Qty: {{printf "%.2f" .Trade.Exit.Quantity}} | Fees: {{printf "%.2f" .Trade.Exit.Fees}}</p>
+        {{if .Trade.Exit.Reason}}<p><strong>Reason:</strong> {{.Trade.Exit.Reason}}</p>{{end}}
+        {{if .Trade.Exit.Notes}}<p>{{.Trade.Exit.Notes}}</p>{{end}}
+    {{else}}
+        <p>Position still open. Unrealized P&amp;L at custom price:</p>
+        <form class="flex" method="get">
+            <label>Reference price</label>
+            <input type="number" step="0.0001" name="close_price" value="{{if .QueryClose}}{{printf "%.4f" .QueryClose}}{{end}}">
+            <button class="btn" type="submit">Update</button>
+        </form>
+        {{if .QueryClose}}
+        <div class="metric-card" style="margin-top:1rem;">
+            <h4>Unrealized</h4>
+            <p>{{printf "%.2f" .Metrics.Unrealized}} ({{printf "%.2f" .Metrics.UnrealizedPct}}%)</p>
+        </div>
+        {{end}}
+    {{end}}
+</div>
+
+<div class="section">
+    <h3>Risk management</h3>
+    {{if .Trade.RiskManagement.Thesis}}<p><strong>Thesis:</strong> {{.Trade.RiskManagement.Thesis}}</p>{{end}}
+    {{if .Trade.RiskManagement.Plan}}<p><strong>Plan:</strong> {{.Trade.RiskManagement.Plan}}</p>{{end}}
+    {{if .Trade.RiskManagement.Checklist}}<p><strong>Checklist:</strong> {{.Trade.RiskManagement.Checklist}}</p>{{end}}
+    {{if gt .Trade.RiskManagement.MaxRiskAmount 0}}<p><strong>Max risk:</strong> {{printf "%.2f" .Trade.RiskManagement.MaxRiskAmount}}</p>{{end}}
+    {{if .Trade.RiskManagement.PositionSizing}}<p><strong>Position sizing:</strong> {{.Trade.RiskManagement.PositionSizing}}</p>{{end}}
+    {{if .Trade.RiskManagement.ContingencyPlan}}<p><strong>Contingency:</strong> {{.Trade.RiskManagement.ContingencyPlan}}</p>{{end}}
+</div>
+
+<div class="section">
+    <h3>Review</h3>
+    {{if .Trade.Review.OutcomeSummary}}<p><strong>Outcome:</strong> {{.Trade.Review.OutcomeSummary}}</p>{{end}}
+    {{if .Trade.Review.Psychology}}<p><strong>Psychology:</strong> {{.Trade.Review.Psychology}}</p>{{end}}
+    {{if .Trade.Review.Improvements}}<p><strong>Improvements:</strong> {{.Trade.Review.Improvements}}</p>{{end}}
+    {{if .Trade.Review.Tags}}
+    <div class="flex">
+        {{range .Trade.Review.Tags}}<span class="tag">{{.}}</span>{{end}}
+    </div>
+    {{end}}
+</div>
+
+<div class="section">
+    <h3>Follow-ups</h3>
+    <form method="post" action="/trades/{{.Trade.ID}}/followups" class="grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+        <div>
+            <label>Days after exit</label>
+            <input type="number" name="days_after" min="1" required>
+        </div>
+        <div>
+            <label>Price</label>
+            <input type="number" step="0.0001" name="price" required>
+        </div>
+        <div>
+            <label>Notes</label>
+            <input type="text" name="notes">
+        </div>
+        <div style="align-self:end;">
+            <button class="btn" type="submit">Add follow-up</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>Days after</th>
+                <th>Price</th>
+                <th>Change vs exit</th>
+                <th>Logged</th>
+                <th>Notes</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Trade.FollowUps}}
+            <tr>
+                <td>{{.DaysAfter}}</td>
+                <td>{{printf "%.2f" .Price}}</td>
+                <td>{{if $.Trade.Exit}}{{printf "%.2f" (followUpChange $.Trade .)}}%{{else}}N/A{{end}}</td>
+                <td>{{.LoggedAt.Format "2006-01-02 15:04"}}</td>
+                <td>{{.Notes}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="5">No follow-ups recorded.</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+
+<div class="section">
+    {{if .Trade.MarketContext}}<p><strong>Market context:</strong> {{.Trade.MarketContext}}</p>{{end}}
+    {{if .Trade.AdditionalNotes}}<p><strong>Notes:</strong> {{.Trade.AdditionalNotes}}</p>{{end}}
+    <div class="flex">
+        {{if .Trade.ExecutionScore}}<span class="badge">Execution: {{printf "%.1f" (ptrValue .Trade.ExecutionScore)}}</span>{{end}}
+        {{if .Trade.ConfidenceBefore}}<span class="badge">Confidence before: {{printf "%.1f" (ptrValue .Trade.ConfidenceBefore)}}</span>{{end}}
+        {{if .Trade.ConfidenceAfter}}<span class="badge">Confidence after: {{printf "%.1f" (ptrValue .Trade.ConfidenceAfter)}}</span>{{end}}
+    </div>
+</div>
+{{end}}
+{{template "layout" .}}

--- a/internal/web/templates/trade_form.gohtml
+++ b/internal/web/templates/trade_form.gohtml
@@ -1,0 +1,135 @@
+{{define "title"}}{{.Title}}{{end}}
+{{define "content"}}
+<h1>{{.Title}}</h1>
+<form method="post" action="{{.Action}}">
+    <div class="grid">
+        <div>
+            <label>Instrument</label>
+            <input type="text" name="instrument" value="{{.Trade.Instrument}}" required>
+        </div>
+        <div>
+            <label>Market</label>
+            <input type="text" name="market" value="{{.Trade.Market}}">
+        </div>
+        <div>
+            <label>Direction</label>
+            <select name="direction">
+                <option value="LONG" {{if eq .Trade.Direction "LONG"}}selected{{end}}>Long</option>
+                <option value="SHORT" {{if eq .Trade.Direction "SHORT"}}selected{{end}}>Short</option>
+            </select>
+        </div>
+        <div>
+            <label>Setup</label>
+            <input type="text" name="setup" value="{{.Trade.Setup}}">
+        </div>
+    </div>
+
+    <h3 class="section">Entry</h3>
+    <div class="grid">
+        <div>
+            <label>Date</label>
+            <input type="date" name="entry_date" value="{{if .Trade.Entry.Date.IsZero}}{{else}}{{.Trade.Entry.Date.Format "2006-01-02"}}{{end}}" required>
+        </div>
+        <div>
+            <label>Price</label>
+            <input type="number" step="0.0001" name="entry_price" value="{{printf "%.4f" .Trade.Entry.Price}}" required>
+        </div>
+        <div>
+            <label>Quantity</label>
+            <input type="number" step="0.0001" name="entry_quantity" value="{{printf "%.4f" .Trade.Entry.Quantity}}" required>
+        </div>
+        <div>
+            <label>Fees</label>
+            <input type="number" step="0.01" name="entry_fees" value="{{printf "%.2f" .Trade.Entry.Fees}}">
+        </div>
+        <div>
+            <label>Stop loss</label>
+            <input type="number" step="0.0001" name="entry_stop_loss" value="{{if .Trade.Entry.StopLoss}}{{printf "%.4f" (ptrValue .Trade.Entry.StopLoss)}}{{end}}">
+        </div>
+        <div>
+            <label>Target</label>
+            <input type="number" step="0.0001" name="entry_target" value="{{if .Trade.Entry.Target}}{{printf "%.4f" (ptrValue .Trade.Entry.Target)}}{{end}}">
+        </div>
+        <div>
+            <label>Manual risk/share</label>
+            <input type="number" step="0.0001" name="entry_risk" value="{{if .Trade.Entry.RiskPerShare}}{{printf "%.4f" (ptrValue .Trade.Entry.RiskPerShare)}}{{end}}">
+        </div>
+    </div>
+    <label>Entry notes</label>
+    <textarea name="entry_notes">{{.Trade.Entry.Notes}}</textarea>
+
+    <h3 class="section">Risk management &amp; plan</h3>
+    <label>Trade thesis</label>
+    <textarea name="thesis">{{.Trade.RiskManagement.Thesis}}</textarea>
+    <label>Plan</label>
+    <textarea name="plan">{{.Trade.RiskManagement.Plan}}</textarea>
+    <label>Checklist confirmation</label>
+    <textarea name="checklist">{{.Trade.RiskManagement.Checklist}}</textarea>
+    <label>Max risk amount</label>
+    <input type="number" step="0.01" name="max_risk" value="{{printf "%.2f" .Trade.RiskManagement.MaxRiskAmount}}">
+    <label>Position sizing logic</label>
+    <textarea name="position_sizing">{{.Trade.RiskManagement.PositionSizing}}</textarea>
+    <label>Contingency plan</label>
+    <textarea name="contingency_plan">{{.Trade.RiskManagement.ContingencyPlan}}</textarea>
+
+    <h3 class="section">Exit (optional)</h3>
+    <div class="grid">
+        <div>
+            <label>Date</label>
+            <input type="date" name="exit_date" value="{{if .Trade.Exit}}{{.Trade.Exit.Date.Format "2006-01-02"}}{{end}}">
+        </div>
+        <div>
+            <label>Price</label>
+            <input type="number" step="0.0001" name="exit_price" value="{{if .Trade.Exit}}{{printf "%.4f" .Trade.Exit.Price}}{{end}}">
+        </div>
+        <div>
+            <label>Quantity</label>
+            <input type="number" step="0.0001" name="exit_quantity" value="{{if .Trade.Exit}}{{printf "%.4f" .Trade.Exit.Quantity}}{{end}}">
+        </div>
+        <div>
+            <label>Fees</label>
+            <input type="number" step="0.01" name="exit_fees" value="{{if .Trade.Exit}}{{printf "%.2f" .Trade.Exit.Fees}}{{end}}">
+        </div>
+    </div>
+    <label>Exit reason</label>
+    <textarea name="exit_reason">{{if .Trade.Exit}}{{.Trade.Exit.Reason}}{{end}}</textarea>
+    <label>Exit notes</label>
+    <textarea name="exit_notes">{{if .Trade.Exit}}{{.Trade.Exit.Notes}}{{end}}</textarea>
+
+    <h3 class="section">Post-trade review</h3>
+    <label>Outcome summary</label>
+    <textarea name="outcome">{{.Trade.Review.OutcomeSummary}}</textarea>
+    <label>Psychology</label>
+    <textarea name="psychology">{{.Trade.Review.Psychology}}</textarea>
+    <label>Improvements</label>
+    <textarea name="improvements">{{.Trade.Review.Improvements}}</textarea>
+    <label>Tags (comma separated)</label>
+    <input type="text" name="tags" value="{{join .Trade.Review.Tags ", "}}">
+
+    <h3 class="section">Additional context</h3>
+    <label>Market context</label>
+    <textarea name="market_context">{{.Trade.MarketContext}}</textarea>
+    <label>Additional notes</label>
+    <textarea name="additional_notes">{{.Trade.AdditionalNotes}}</textarea>
+    <div class="grid">
+        <div>
+            <label>Execution score (0-10)</label>
+            <input type="number" step="0.1" name="execution_score" value="{{if .Trade.ExecutionScore}}{{printf "%.1f" (ptrValue .Trade.ExecutionScore)}}{{end}}">
+        </div>
+        <div>
+            <label>Confidence before</label>
+            <input type="number" step="0.1" name="confidence_before" value="{{if .Trade.ConfidenceBefore}}{{printf "%.1f" (ptrValue .Trade.ConfidenceBefore)}}{{end}}">
+        </div>
+        <div>
+            <label>Confidence after</label>
+            <input type="number" step="0.1" name="confidence_after" value="{{if .Trade.ConfidenceAfter}}{{printf "%.1f" (ptrValue .Trade.ConfidenceAfter)}}{{end}}">
+        </div>
+    </div>
+
+    <div class="section flex" style="justify-content:flex-end;">
+        <button class="btn" type="submit">Save trade</button>
+        <a class="btn-secondary" href="/">Cancel</a>
+    </div>
+</form>
+{{end}}
+{{template "layout" .}}


### PR DESCRIPTION
## Summary
- implement a rich trade domain model with risk metrics, follow-up tracking, and supporting service logic
- add storage implementations for in-memory usage plus a MongoDB repository behind a build tag
- expose a web UI with forms, detail views, and follow-up management along with a runnable server entrypoint and documentation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d2c4ba86d8832eb1d02ef95625d3cb